### PR TITLE
fix typo in spec

### DIFF
--- a/spec/github_post_receive_server/rack_app_spec.rb
+++ b/spec/github_post_receive_server/rack_app_spec.rb
@@ -11,7 +11,7 @@ describe "Rack Post-Receive Server :-P" do
     res.should.be.ok
     res.should.match /be.*gone.*foul/i # *evil grin*
   end
-  it "should reply with a rude message on GET" do 
+  it "should reply with a rude message on POST without a payload" do 
     req = Rack::MockRequest.new(@server)
     res = req.post("/", {})
     res.should.be.ok


### PR DESCRIPTION
This is a POST request without a payload not a GET request.
